### PR TITLE
Fixed a tiny spelling mistake in the Sponsor thanks section

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             </div>
             <div class="col-sm-6">
               <p>
-              PacBSD is grateful to our hosting sponsors who help keep the ligts on and allow us to concentrate on development.
+              PacBSD is grateful to our hosting sponsors who help keep the lights on and allow us to concentrate on development.
               </p>
             </div>
             <div class="col-sm-6">

--- a/themes/hugo-theme-arch/layouts/partials/footer.html
+++ b/themes/hugo-theme-arch/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             </div>
             <div class="col-sm-6">
               <p>
-              PacBSD is grateful to our hosting sponsors who help keep the ligts on and allow us to concentrate on development.
+              PacBSD is grateful to our hosting sponsors who help keep the lights on and allow us to concentrate on development.
               </p>
             </div>
             <div class="col-sm-6">


### PR DESCRIPTION
Also, the description for the PacBSD organization doesn't have proper english grammar.

> Repositories for PacBSD (formerly ArchBSD) - A FreeBSD distribution using the Arch's pacman package manager

Should say:

Repositories for PacBSD (formerly ArchBSD) - A FreeBSD distribution using Arch's pacman package manager