### PR TITLE
fix mathjax

### DIFF
--- a/themes/hugo-theme-arch/layouts/partials/footer_js.html
+++ b/themes/hugo-theme-arch/layouts/partials/footer_js.html
@@ -12,7 +12,7 @@ MathJax.Hub.Config({
     inlineMath: [['$','$'], ['\\(','\\)']]}
   });
 </script>
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
 <!--
 <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 -->

--- a/themes/hugo-theme-arch/layouts/partials/head.html
+++ b/themes/hugo-theme-arch/layouts/partials/head.html
@@ -32,7 +32,7 @@
     <script src="{{ .Site.BaseURL }}js/script.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.8.0/highlight.min.js"></script>
     <script>hljs.initHighlightingOnLoad();</script>
-    
+
     <!-- MathJax -->
     <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
@@ -40,7 +40,7 @@
         inlineMath: [['$','$'], ['\\(','\\)']]}
       });
     </script>
-    <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js"></script>
 
     <!-- hotkeys -->
     <script src="{{ .Site.BaseURL }}js/jquery.hotkeys.js "></script>


### PR DESCRIPTION
I think there might be one more reference to the outdated source of mathjax, but this pr removes 2 mentions of mathjax and replaces them with the needed value